### PR TITLE
Add account registration screen with validations

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MisElectros">
+        <activity android:name=".RegisterActivity" android:exported="false"/>
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/example/miselectros/MainActivity.kt
+++ b/app/src/main/java/com/example/miselectros/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.example.miselectros
 
+import android.content.Intent
 import android.os.Bundle
+import android.widget.TextView
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
@@ -15,6 +17,10 @@ class MainActivity : AppCompatActivity() {
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
+        }
+
+        findViewById<TextView>(R.id.create_account).setOnClickListener {
+            startActivity(Intent(this, RegisterActivity::class.java))
         }
     }
 }

--- a/app/src/main/java/com/example/miselectros/RegisterActivity.kt
+++ b/app/src/main/java/com/example/miselectros/RegisterActivity.kt
@@ -1,0 +1,97 @@
+package com.example.miselectros
+
+import android.os.Bundle
+import android.util.Patterns
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
+
+class RegisterActivity : AppCompatActivity() {
+
+    private lateinit var fullNameLayout: TextInputLayout
+    private lateinit var emailLayout: TextInputLayout
+    private lateinit var passwordLayout: TextInputLayout
+    private lateinit var confirmPasswordLayout: TextInputLayout
+
+    private lateinit var fullNameInput: TextInputEditText
+    private lateinit var emailInput: TextInputEditText
+    private lateinit var passwordInput: TextInputEditText
+    private lateinit var confirmPasswordInput: TextInputEditText
+    private lateinit var registerButton: MaterialButton
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_register)
+
+        fullNameLayout = findViewById(R.id.full_name_layout)
+        emailLayout = findViewById(R.id.register_email_layout)
+        passwordLayout = findViewById(R.id.register_password_layout)
+        confirmPasswordLayout = findViewById(R.id.confirm_password_layout)
+
+        fullNameInput = findViewById(R.id.full_name_input)
+        emailInput = findViewById(R.id.register_email_input)
+        passwordInput = findViewById(R.id.register_password_input)
+        confirmPasswordInput = findViewById(R.id.confirm_password_input)
+        registerButton = findViewById(R.id.register_button)
+
+        registerButton.setOnClickListener {
+            if (validateInputs()) {
+                // Proceed with account creation logic
+            }
+        }
+    }
+
+    private fun validateInputs(): Boolean {
+        var valid = true
+
+        val fullName = fullNameInput.text?.toString()?.trim().orEmpty()
+        val email = emailInput.text?.toString()?.trim().orEmpty()
+        val password = passwordInput.text?.toString().orEmpty()
+        val confirmPassword = confirmPasswordInput.text?.toString().orEmpty()
+
+        if (fullName.isEmpty()) {
+            fullNameLayout.error = getString(R.string.error_full_name)
+            valid = false
+        } else {
+            fullNameLayout.error = null
+        }
+
+        if (email.isEmpty()) {
+            emailLayout.error = getString(R.string.error_email_required)
+            valid = false
+        } else if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+            emailLayout.error = getString(R.string.error_invalid_email)
+            valid = false
+        } else {
+            emailLayout.error = null
+        }
+
+        if (password.isEmpty()) {
+            passwordLayout.error = getString(R.string.error_password_required)
+            valid = false
+        } else if (!isValidPassword(password)) {
+            passwordLayout.error = getString(R.string.error_invalid_password)
+            valid = false
+        } else {
+            passwordLayout.error = null
+        }
+
+        if (confirmPassword.isEmpty()) {
+            confirmPasswordLayout.error = getString(R.string.error_confirm_password_required)
+            valid = false
+        } else if (password != confirmPassword) {
+            confirmPasswordLayout.error = getString(R.string.error_passwords_not_match)
+            valid = false
+        } else {
+            confirmPasswordLayout.error = null
+        }
+
+        return valid
+    }
+
+    private fun isValidPassword(password: String): Boolean {
+        val regex = Regex("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{8,}")
+        return regex.matches(password)
+    }
+}

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp"
+    tools:context=".RegisterActivity">
+
+    <LinearLayout
+        android:id="@+id/register_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/full_name_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/full_name_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/full_name"
+                android:inputType="textPersonName" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/register_email_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/register_email_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/email"
+                android:inputType="textEmailAddress" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/register_password_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/register_password_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/password"
+                android:inputType="textPassword" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/confirm_password_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/confirm_password_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/confirm_password"
+                android:inputType="textPassword" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/register_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/register" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,14 @@
     <string name="login">Iniciar sesión</string>
     <string name="create_account">Crear cuenta</string>
     <string name="forgot_password">Restablecer contraseña</string>
+    <string name="full_name">Nombre completo</string>
+    <string name="confirm_password">Repetir contraseña</string>
+    <string name="register">Registrar</string>
+    <string name="error_full_name">Ingrese su nombre completo</string>
+    <string name="error_email_required">Ingrese un email</string>
+    <string name="error_invalid_email">Ingrese un email válido</string>
+    <string name="error_password_required">Ingrese una contraseña</string>
+    <string name="error_invalid_password">La contraseña debe tener al menos 8 caracteres, incluir mayúsculas, minúsculas y números</string>
+    <string name="error_confirm_password_required">Repita la contraseña</string>
+    <string name="error_passwords_not_match">Las contraseñas no coinciden</string>
 </resources>


### PR DESCRIPTION
## Summary
- add registration activity with full name, email and password confirmation fields
- validate user input and show helpful error messages
- link create account action from main screen and register activity in manifest

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894fb637768832cb1de2c0ed0f84956