### PR TITLE
Add toolbar with navigation to register screen

### DIFF
--- a/app/src/main/java/com/example/miselectros/RegisterActivity.kt
+++ b/app/src/main/java/com/example/miselectros/RegisterActivity.kt
@@ -3,6 +3,7 @@ package com.example.miselectros
 import android.os.Bundle
 import android.util.Patterns
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
@@ -24,6 +25,10 @@ class RegisterActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_register)
 
+        val toolbar: MaterialToolbar = findViewById(R.id.register_toolbar)
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
         fullNameLayout = findViewById(R.id.full_name_layout)
         emailLayout = findViewById(R.id.register_email_layout)
         passwordLayout = findViewById(R.id.register_password_layout)
@@ -40,6 +45,11 @@ class RegisterActivity : AppCompatActivity() {
                 // Proceed with account creation logic
             }
         }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        finish()
+        return true
     }
 
     private fun validateInputs(): Boolean {

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -4,15 +4,25 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="24dp"
     tools:context=".RegisterActivity">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/register_toolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:title="@string/create_account"
+        app:titleCentered="true" />
 
     <LinearLayout
         android:id="@+id/register_container"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintTop_toTopOf="parent"
+        android:padding="24dp"
+        app:layout_constraintTop_toBottomOf="@id/register_toolbar"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">


### PR DESCRIPTION
## Summary
- add Material toolbar with centered title to registration layout
- wire up toolbar for up navigation in RegisterActivity

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894ff442258832cac2f440da5cbc7c2