### PR TITLE
Add password reset flow with code verification

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,8 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.MisElectros">
         <activity android:name=".RegisterActivity" android:exported="false"/>
+        <activity android:name=".ResetPasswordActivity" android:exported="false"/>
+        <activity android:name=".CodeVerificationActivity" android:exported="false"/>
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/example/miselectros/CodeVerificationActivity.kt
+++ b/app/src/main/java/com/example/miselectros/CodeVerificationActivity.kt
@@ -1,0 +1,50 @@
+package com.example.miselectros
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
+
+class CodeVerificationActivity : AppCompatActivity() {
+
+    private lateinit var codeLayout: TextInputLayout
+    private lateinit var codeInput: TextInputEditText
+    private lateinit var validateButton: MaterialButton
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_code_verification)
+
+        val toolbar: MaterialToolbar = findViewById(R.id.code_toolbar)
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        codeLayout = findViewById(R.id.code_layout)
+        codeInput = findViewById(R.id.code_input)
+        validateButton = findViewById(R.id.validate_code_button)
+
+        validateButton.setOnClickListener {
+            if (validateCode()) {
+                // TODO: implement code validation
+            }
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        finish()
+        return true
+    }
+
+    private fun validateCode(): Boolean {
+        val code = codeInput.text?.toString()?.trim().orEmpty()
+        return if (!code.matches(Regex("^\\d{6}$"))) {
+            codeLayout.error = getString(R.string.error_invalid_code)
+            false
+        } else {
+            codeLayout.error = null
+            true
+        }
+    }
+}

--- a/app/src/main/java/com/example/miselectros/MainActivity.kt
+++ b/app/src/main/java/com/example/miselectros/MainActivity.kt
@@ -22,5 +22,9 @@ class MainActivity : AppCompatActivity() {
         findViewById<TextView>(R.id.create_account).setOnClickListener {
             startActivity(Intent(this, RegisterActivity::class.java))
         }
+
+        findViewById<TextView>(R.id.forgot_password).setOnClickListener {
+            startActivity(Intent(this, ResetPasswordActivity::class.java))
+        }
     }
 }

--- a/app/src/main/java/com/example/miselectros/ResetPasswordActivity.kt
+++ b/app/src/main/java/com/example/miselectros/ResetPasswordActivity.kt
@@ -1,0 +1,56 @@
+package com.example.miselectros
+
+import android.content.Intent
+import android.os.Bundle
+import android.util.Patterns
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
+
+class ResetPasswordActivity : AppCompatActivity() {
+
+    private lateinit var emailLayout: TextInputLayout
+    private lateinit var emailInput: TextInputEditText
+    private lateinit var resetButton: MaterialButton
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_reset_password)
+
+        val toolbar: MaterialToolbar = findViewById(R.id.reset_password_toolbar)
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        emailLayout = findViewById(R.id.reset_email_layout)
+        emailInput = findViewById(R.id.reset_email_input)
+        resetButton = findViewById(R.id.reset_password_button)
+
+        resetButton.setOnClickListener {
+            if (validateEmail()) {
+                // TODO: trigger backend to send code
+                startActivity(Intent(this, CodeVerificationActivity::class.java))
+            }
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        finish()
+        return true
+    }
+
+    private fun validateEmail(): Boolean {
+        val email = emailInput.text?.toString()?.trim().orEmpty()
+        return if (email.isEmpty()) {
+            emailLayout.error = getString(R.string.error_email_required)
+            false
+        } else if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+            emailLayout.error = getString(R.string.error_invalid_email)
+            false
+        } else {
+            emailLayout.error = null
+            true
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_code_verification.xml
+++ b/app/src/main/res/layout/activity_code_verification.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".CodeVerificationActivity">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/code_toolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:title="@string/validate_code"
+        app:titleCentered="true" />
+
+    <LinearLayout
+        android:id="@+id/code_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp"
+        app:layout_constraintTop_toBottomOf="@id/code_toolbar"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/code_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/code_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/verification_code"
+                android:inputType="number" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/validate_code_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/validate_code" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_reset_password.xml
+++ b/app/src/main/res/layout/activity_reset_password.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ResetPasswordActivity">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/reset_password_toolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:title="@string/forgot_password"
+        app:titleCentered="true" />
+
+    <LinearLayout
+        android:id="@+id/reset_password_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp"
+        app:layout_constraintTop_toBottomOf="@id/reset_password_toolbar"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/reset_email_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/reset_email_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/email"
+                android:inputType="textEmailAddress" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/reset_password_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/forgot_password" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,7 @@
     <string name="error_invalid_password">La contraseña debe tener al menos 8 caracteres, incluir mayúsculas, minúsculas y números</string>
     <string name="error_confirm_password_required">Repita la contraseña</string>
     <string name="error_passwords_not_match">Las contraseñas no coinciden</string>
+    <string name="verification_code">Código de verificación</string>
+    <string name="validate_code">Validar código</string>
+    <string name="error_invalid_code">Ingrese un código de 6 dígitos</string>
 </resources>


### PR DESCRIPTION
## Summary
- add password reset screen with email validation and navigation to code input
- add code verification screen with 6-digit check
- link reset flow from main screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68950535875c832cb2b12d6c9a079642