### PR TITLE
Add home screen with navigation drawer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MisElectros">
+        <activity android:name=".HomeActivity" android:exported="false"/>
         <activity android:name=".RegisterActivity" android:exported="false"/>
         <activity android:name=".ResetPasswordActivity" android:exported="false"/>
         <activity android:name=".CodeVerificationActivity" android:exported="false"/>

--- a/app/src/main/java/com/example/miselectros/HomeActivity.kt
+++ b/app/src/main/java/com/example/miselectros/HomeActivity.kt
@@ -1,0 +1,60 @@
+package com.example.miselectros
+
+import android.os.Bundle
+import android.view.MenuItem
+import android.widget.Toast
+import androidx.appcompat.app.ActionBarDrawerToggle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.GravityCompat
+import androidx.drawerlayout.widget.DrawerLayout
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.navigation.NavigationView
+
+class HomeActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelectedListener {
+
+    private lateinit var drawerLayout: DrawerLayout
+    private lateinit var navigationView: NavigationView
+    private lateinit var toggle: ActionBarDrawerToggle
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_home)
+
+        val toolbar: MaterialToolbar = findViewById(R.id.toolbar)
+        setSupportActionBar(toolbar)
+
+        drawerLayout = findViewById(R.id.drawer_layout)
+        navigationView = findViewById(R.id.nav_view)
+
+        toggle = ActionBarDrawerToggle(
+            this,
+            drawerLayout,
+            toolbar,
+            R.string.navigation_drawer_open,
+            R.string.navigation_drawer_close
+        )
+        drawerLayout.addDrawerListener(toggle)
+        toggle.syncState()
+
+        navigationView.setNavigationItemSelectedListener(this)
+    }
+
+    override fun onNavigationItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            R.id.nav_modify_data -> {
+                Toast.makeText(this, R.string.nav_modify_data, Toast.LENGTH_SHORT).show()
+            }
+            R.id.nav_my_plan -> {
+                Toast.makeText(this, R.string.nav_my_plan, Toast.LENGTH_SHORT).show()
+            }
+            R.id.nav_settings -> {
+                Toast.makeText(this, R.string.nav_settings, Toast.LENGTH_SHORT).show()
+            }
+            R.id.nav_logout -> {
+                finish()
+            }
+        }
+        drawerLayout.closeDrawer(GravityCompat.START)
+        return true
+    }
+}

--- a/app/src/main/java/com/example/miselectros/MainActivity.kt
+++ b/app/src/main/java/com/example/miselectros/MainActivity.kt
@@ -38,7 +38,8 @@ class MainActivity : AppCompatActivity() {
 
         loginButton.setOnClickListener {
             if (validateInputs()) {
-                // Proceed with login logic
+                startActivity(Intent(this, HomeActivity::class.java))
+                finish()
             }
         }
 

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".HomeActivity">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/colorPrimary"
+            android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"
+            app:title="@string/app_name" />
+
+        <FrameLayout
+            android:id="@+id/content_frame"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </LinearLayout>
+
+    <com.google.android.material.navigation.NavigationView
+        android:id="@+id/nav_view"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        app:headerLayout="@layout/nav_header_home"
+        app:menu="@menu/drawer_menu" />
+
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/nav_header_home.xml
+++ b/app/src/main/res/layout/nav_header_home.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="160dp"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="16dp">
+
+    <ImageView
+        android:id="@+id/profile_image"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        android:src="@mipmap/ic_launcher_foreground"
+        android:contentDescription="@string/app_name" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/nav_header_home.xml
+++ b/app/src/main/res/layout/nav_header_home.xml
@@ -10,7 +10,7 @@
         android:id="@+id/profile_image"
         android:layout_width="80dp"
         android:layout_height="80dp"
-        android:src="@mipmap/ic_launcher_foreground"
+        android:src="@mipmap/ic_launcher_round"
         android:contentDescription="@string/app_name" />
 
 </LinearLayout>

--- a/app/src/main/res/menu/drawer_menu.xml
+++ b/app/src/main/res/menu/drawer_menu.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/nav_modify_data"
+        android:title="@string/nav_modify_data" />
+    <item
+        android:id="@+id/nav_my_plan"
+        android:title="@string/nav_my_plan" />
+    <item
+        android:id="@+id/nav_settings"
+        android:title="@string/nav_settings" />
+    <item
+        android:id="@+id/nav_logout"
+        android:title="@string/nav_logout" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,10 @@
     <string name="verification_code">Código de verificación</string>
     <string name="validate_code">Validar código</string>
     <string name="error_invalid_code">Ingrese un código de 6 dígitos</string>
+    <string name="nav_modify_data">Modificar mis datos</string>
+    <string name="nav_my_plan">Mi plan</string>
+    <string name="nav_settings">Configuración</string>
+    <string name="nav_logout">Salir</string>
+    <string name="navigation_drawer_open">Abrir navegación</string>
+    <string name="navigation_drawer_close">Cerrar navegación</string>
 </resources>


### PR DESCRIPTION
## Summary
- Redirect login to new Home screen
- Implement HomeActivity with drawer menu and placeholder actions
- Add resources for navigation header, menu and strings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895aa9e0a40832cab15b82161f2b807