### PR TITLE
Add documents section with creation flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MisElectros">
+        <activity android:name=".CreateDocumentActivity" android:exported="false"/>
+        <activity android:name=".DocumentsActivity" android:exported="false"/>
         <activity android:name=".HomeActivity" android:exported="false"/>
         <activity android:name=".RegisterActivity" android:exported="false"/>
         <activity android:name=".ResetPasswordActivity" android:exported="false"/>

--- a/app/src/main/java/com/example/miselectros/CreateDocumentActivity.kt
+++ b/app/src/main/java/com/example/miselectros/CreateDocumentActivity.kt
@@ -1,0 +1,57 @@
+package com.example.miselectros
+
+import android.os.Bundle
+import android.widget.*
+import androidx.appcompat.app.AppCompatActivity
+
+class CreateDocumentActivity : AppCompatActivity() {
+
+    private val types = listOf("Factura", "Recibo", "Otro")
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        showStep1()
+    }
+
+    private fun showStep1() {
+        setContentView(R.layout.activity_document_step1)
+        val nameField: EditText = findViewById(R.id.edit_name)
+        val typeSpinner: Spinner = findViewById(R.id.spinner_type)
+        val dateField: EditText = findViewById(R.id.edit_date)
+        val storeField: EditText = findViewById(R.id.edit_store)
+        val descriptionField: EditText = findViewById(R.id.edit_description)
+
+        val adapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, types)
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        typeSpinner.adapter = adapter
+
+        intent.getStringExtra("name")?.let { nameField.setText(it) }
+        intent.getStringExtra("type")?.let { t ->
+            val pos = types.indexOf(t)
+            if (pos >= 0) typeSpinner.setSelection(pos)
+        }
+
+        findViewById<Button>(R.id.button_next).setOnClickListener {
+            val name = nameField.text.toString().trim()
+            if (name.isEmpty()) {
+                nameField.error = getString(R.string.required)
+                return@setOnClickListener
+            }
+            showStep2()
+        }
+    }
+
+    private fun showStep2() {
+        setContentView(R.layout.activity_document_step2)
+        findViewById<Button>(R.id.button_camera).setOnClickListener {
+            Toast.makeText(this, R.string.camera_action, Toast.LENGTH_SHORT).show()
+        }
+        findViewById<Button>(R.id.button_file).setOnClickListener {
+            Toast.makeText(this, R.string.choose_file_action, Toast.LENGTH_SHORT).show()
+        }
+        findViewById<Button>(R.id.button_save).setOnClickListener {
+            Toast.makeText(this, R.string.save, Toast.LENGTH_SHORT).show()
+            finish()
+        }
+    }
+}

--- a/app/src/main/java/com/example/miselectros/Document.kt
+++ b/app/src/main/java/com/example/miselectros/Document.kt
@@ -1,0 +1,3 @@
+package com.example.miselectros
+
+data class Document(val id: Int, val name: String, val type: String)

--- a/app/src/main/java/com/example/miselectros/DocumentAdapter.kt
+++ b/app/src/main/java/com/example/miselectros/DocumentAdapter.kt
@@ -1,0 +1,44 @@
+package com.example.miselectros
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.BaseAdapter
+import android.widget.ImageButton
+import android.widget.TextView
+
+class DocumentAdapter(
+    private val context: Context,
+    private val documents: MutableList<Document>,
+    private val listener: DocumentActionListener
+) : BaseAdapter() {
+
+    interface DocumentActionListener {
+        fun onEdit(document: Document)
+        fun onDelete(document: Document)
+    }
+
+    override fun getCount(): Int = documents.size
+
+    override fun getItem(position: Int): Document = documents[position]
+
+    override fun getItemId(position: Int): Long = documents[position].id.toLong()
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val view = convertView ?: LayoutInflater.from(context).inflate(R.layout.item_document, parent, false)
+        val document = getItem(position)
+        val name: TextView = view.findViewById(R.id.text_name)
+        val type: TextView = view.findViewById(R.id.text_type)
+        val editButton: ImageButton = view.findViewById(R.id.btn_edit)
+        val deleteButton: ImageButton = view.findViewById(R.id.btn_delete)
+
+        name.text = document.name
+        type.text = document.type
+
+        editButton.setOnClickListener { listener.onEdit(document) }
+        deleteButton.setOnClickListener { listener.onDelete(document) }
+
+        return view
+    }
+}

--- a/app/src/main/java/com/example/miselectros/DocumentsActivity.kt
+++ b/app/src/main/java/com/example/miselectros/DocumentsActivity.kt
@@ -1,0 +1,63 @@
+package com.example.miselectros
+
+import android.app.AlertDialog
+import android.content.Intent
+import android.os.Bundle
+import android.widget.ListView
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import org.json.JSONArray
+
+class DocumentsActivity : AppCompatActivity(), DocumentAdapter.DocumentActionListener {
+
+    private lateinit var documents: MutableList<Document>
+    private lateinit var listView: ListView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_documents)
+
+        listView = findViewById(R.id.documents_list_view)
+        documents = loadDocuments()
+        listView.adapter = DocumentAdapter(this, documents, this)
+
+        findViewById<FloatingActionButton>(R.id.fab_add_document).setOnClickListener {
+            startActivity(Intent(this, CreateDocumentActivity::class.java))
+        }
+    }
+
+    private fun loadDocuments(): MutableList<Document> {
+        val mockJson = """
+            [
+              {"id":1,"name":"Factura de luz","type":"Factura"},
+              {"id":2,"name":"Recibo de agua","type":"Recibo"}
+            ]
+        """
+        val arr = JSONArray(mockJson)
+        val list = mutableListOf<Document>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.getJSONObject(i)
+            list.add(Document(obj.getInt("id"), obj.getString("name"), obj.getString("type")))
+        }
+        return list
+    }
+
+    override fun onEdit(document: Document) {
+        val intent = Intent(this, CreateDocumentActivity::class.java)
+        intent.putExtra("name", document.name)
+        intent.putExtra("type", document.type)
+        startActivity(intent)
+    }
+
+    override fun onDelete(document: Document) {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.title_documents)
+            .setMessage(R.string.delete_confirmation)
+            .setPositiveButton(R.string.yes) { _, _ ->
+                documents.remove(document)
+                (listView.adapter as DocumentAdapter).notifyDataSetChanged()
+            }
+            .setNegativeButton(R.string.no, null)
+            .show()
+    }
+}

--- a/app/src/main/java/com/example/miselectros/HomeActivity.kt
+++ b/app/src/main/java/com/example/miselectros/HomeActivity.kt
@@ -1,5 +1,6 @@
 package com.example.miselectros
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import android.widget.Toast
@@ -41,6 +42,9 @@ class HomeActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
+            R.id.nav_my_documents -> {
+                startActivity(Intent(this, DocumentsActivity::class.java))
+            }
             R.id.nav_modify_data -> {
                 Toast.makeText(this, R.string.nav_modify_data, Toast.LENGTH_SHORT).show()
             }

--- a/app/src/main/res/layout/activity_document_step1.xml
+++ b/app/src/main/res/layout/activity_document_step1.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/step1"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:paddingBottom="8dp" />
+
+        <EditText
+            android:id="@+id/edit_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/document_name" />
+
+        <Spinner
+            android:id="@+id/spinner_type"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <EditText
+            android:id="@+id/edit_date"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/document_date" />
+
+        <EditText
+            android:id="@+id/edit_store"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/document_store" />
+
+        <EditText
+            android:id="@+id/edit_description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/document_description"
+            android:inputType="textMultiLine" />
+
+        <Button
+            android:id="@+id/button_next"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/next" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/activity_document_step2.xml
+++ b/app/src/main/res/layout/activity_document_step2.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/step2"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:paddingBottom="8dp" />
+
+    <Button
+        android:id="@+id/button_camera"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/camera_action" />
+
+    <Button
+        android:id="@+id/button_file"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/choose_file_action" />
+
+    <Button
+        android:id="@+id/button_save"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/save" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_documents.xml
+++ b/app/src/main/res/layout/activity_documents.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="16dp"
+            android:text="@string/title_documents"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <ListView
+            android:id="@+id/documents_list_view"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+    </LinearLayout>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_add_document"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        app:srcCompat="@android:drawable/ic_input_add" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/item_document.xml
+++ b/app/src/main/res/layout/item_document.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="8dp">
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/text_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/text_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+    <ImageButton
+        android:id="@+id/btn_edit"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:src="@android:drawable/ic_menu_edit" />
+
+    <ImageButton
+        android:id="@+id/btn_delete"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:src="@android:drawable/ic_menu_delete" />
+
+</LinearLayout>

--- a/app/src/main/res/menu/drawer_menu.xml
+++ b/app/src/main/res/menu/drawer_menu.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
+        android:id="@+id/nav_my_documents"
+        android:title="@string/nav_my_documents" />
+    <item
         android:id="@+id/nav_modify_data"
         android:title="@string/nav_modify_data" />
     <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,4 +24,21 @@
     <string name="nav_logout">Salir</string>
     <string name="navigation_drawer_open">Abrir navegación</string>
     <string name="navigation_drawer_close">Cerrar navegación</string>
+    <string name="nav_my_documents">Mis documentos</string>
+    <string name="title_documents">Mis documentos</string>
+    <string name="step1">Paso 1</string>
+    <string name="step2">Paso 2</string>
+    <string name="next">Siguiente</string>
+    <string name="camera_action">Tomar foto</string>
+    <string name="choose_file_action">Seleccionar archivo</string>
+    <string name="save">Guardar</string>
+    <string name="delete_confirmation">¿Desea eliminar este documento?</string>
+    <string name="yes">Sí</string>
+    <string name="no">No</string>
+    <string name="document_name">Nombre</string>
+    <string name="document_type">Tipo</string>
+    <string name="document_date">Fecha</string>
+    <string name="document_store">Nombre de la tienda</string>
+    <string name="document_description">Descripción</string>
+    <string name="required">Requerido</string>
 </resources>


### PR DESCRIPTION
## Summary
- add "Mis documentos" option in navigation drawer
- implement document list with mock data and actions to add, edit, and delete
- create multi-step form activity for creating or editing documents

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895d5ce3968832c8ce6b63aacb5312c